### PR TITLE
Fixed font location to respect XDG specification if defined

### DIFF
--- a/src/JuliaMono.jl
+++ b/src/JuliaMono.jl
@@ -8,7 +8,10 @@ const TTF_FILES = artifact"JuliaMono"
 
 function install()
     for i in readdir(TTF_FILES)
-        run(`ln -s $(joinpath(TTF_FILES, i)) $(joinpath(ENV["HOME"], ".fonts", i))`)
+        fontfolder = haskey(ENV, "XDG_DATA_HOME") ?
+                         joinpath(ENV["XDG_DATA_HOME"], "fonts") :
+                         joinpath(homedir(), ".fonts")
+        run(`ln -s $(joinpath(TTF_FILES, i)) $(joinpath(fontfolder, i))`)
     end
 end
 


### PR DESCRIPTION
Changed the install location to check if `$XDG_DATA_HOME` is defined to follow the XDG specification. If it isn't, then use the `homedir()` function in julia which handles more cases than just `$HOME`.